### PR TITLE
Add initial Blender Cycles render farm integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
-# My Codex App 
+# R-Farm – Cycles render farm prototype
+
+This repository contains a proof-of-concept implementation of a Blender add-on and a GPU-enabled Google Cloud Run service that together form a minimal render farm for Cycles. The first iteration focuses on rendering a single frame from Blender on demand.
+
+## Project structure
+
+- `blender_addon/` – Blender add-on that exposes a panel inside the **Render Properties** tab. The button submits the current frame together with the existing Cycles settings to the remote worker.
+- `cloud_run/` – Source code and container definition for the Cloud Run GPU worker executing Blender in headless mode.
+
+## Blender add-on
+
+1. Zip the folder:
+   ```bash
+   cd blender_addon
+   zip -r ../rfarm_blender_addon.zip .
+   ```
+2. Inside Blender open **Edit → Preferences → Add-ons** and install the generated archive.
+3. Configure the add-on in **Edit → Preferences → Add-ons → R-Farm Cycles Render**:
+   - **Cloud Run endpoint** – URL of the deployed worker (for example `https://render-worker-xxxxx.a.run.app`).
+   - **Auth token** – Optional bearer token when the worker is protected (for example by Cloud Endpoints or IAP).
+   - The add-on uses the `requests` Python library, which ships with recent Blender releases. If you are running a custom Python build, install it via `pip install requests --target "<blender>/scripts/modules"`.
+4. Switch the render engine to **Cycles** and configure all render parameters as usual (resolution, samples, output path, etc.).
+5. Open the **Render Properties** tab and use the **Render Current Frame on R-Farm** button. The resulting frame is written to the configured output path.
+
+The add-on serialises the current `.blend` file to a temporary location, sends it to the worker, waits for completion, and stores the returned image on disk. Any errors from the worker are surfaced inside Blender.
+
+## Cloud Run GPU worker
+
+The worker is a FastAPI application that receives a `.blend` file (base64-encoded) together with render metadata. It starts Blender in background mode, enforces GPU rendering, and returns the rendered image as a base64 payload.
+
+### Building the container image
+
+```bash
+gcloud builds submit --tag gcr.io/PROJECT_ID/rfarm-render cloud_run
+```
+
+The Docker image installs Blender 3.6.5 on top of an NVIDIA CUDA 12 runtime image and uses `uvicorn` to expose the FastAPI service.
+
+### Deploying to Cloud Run (GPU)
+
+```bash
+gcloud run deploy rfarm-render \
+  --image gcr.io/PROJECT_ID/rfarm-render \
+  --platform managed \
+  --region REGION \
+  --gpu gpu-tesla-t4 \
+  --gpu-count 1 \
+  --memory 16Gi \
+  --cpu 4 \
+  --timeout 15m \
+  --max-instances 1 \
+  --min-instances 0 \
+  --allow-unauthenticated
+```
+
+Adjust the region and GPU type depending on availability. The worker only runs while a render job is executing, allowing you to pay only for active render time. Consider restricting access (e.g. with a service account and Cloud Endpoints) for production deployments.
+
+### API contract
+
+`POST /render`
+
+```json
+{
+  "frame": 1,
+  "blend_file": "base64-encoded data",
+  "render_settings": {
+    "samples": 256,
+    "resolution_x": 1920,
+    "resolution_y": 1080,
+    "resolution_percentage": 100,
+    "file_format": "PNG",
+    "color_mode": "RGB",
+    "color_depth": "8"
+  },
+  "device": "GPU",
+  "compute_device_type": "CUDA"
+}
+```
+
+Successful responses return the rendered image encoded as base64 together with a job identifier.
+
+### Running locally
+
+The service can be tested without deploying to Cloud Run:
+
+```bash
+cd cloud_run
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app:app --reload --host 0.0.0.0 --port 8080
+```
+
+Then point the Blender add-on endpoint to `http://127.0.0.1:8080` (requires Blender to have access to the same Docker daemon or Blender installation to execute renders locally).
+
+## Security and scaling considerations
+
+- Protect the `/render` endpoint with authentication to avoid exposing your render farm to the public Internet.
+- Use Google Cloud Storage for large outputs or animations in future iterations to avoid transferring large payloads back to Blender synchronously.
+- To scale to multiple frames or animations, extend the API to enqueue tasks (for example via Pub/Sub or Cloud Tasks) and stream results asynchronously.
+
+This repository provides the minimal end-to-end scaffolding required to experiment with GPU rendering on demand using Blender and Google Cloud Run.

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1,0 +1,298 @@
+"""Blender add-on for triggering R-Farm remote renders."""
+
+bl_info = {
+    "name": "R-Farm Cycles Render",
+    "author": "R-Farm",
+    "version": (0, 1, 0),
+    "blender": (3, 4, 0),
+    "location": "Properties > Render",
+    "description": "Submit the active frame to an R-Farm Cloud Run render worker",
+    "warning": "",
+    "category": "Render",
+}
+
+import base64
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import bpy
+from bpy.props import BoolProperty, PointerProperty, StringProperty
+from bpy.types import AddonPreferences, Operator, Panel, PropertyGroup
+from bpy.utils import register_class, unregister_class
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+
+class RFarmAddonPreferences(AddonPreferences):
+    bl_idname = __name__
+
+    endpoint: StringProperty(
+        name="Cloud Run endpoint",
+        description="Base URL of the R-Farm Cloud Run render worker",
+        default="",
+    )
+    auth_token: StringProperty(
+        name="Auth token",
+        description=(
+            "Optional bearer token passed to the Cloud Run service. "
+            "Leave empty if authentication is disabled."
+        ),
+        default="",
+        subtype="PASSWORD",
+    )
+
+    def draw(self, _context):
+        layout = self.layout
+        layout.prop(self, "endpoint")
+        layout.prop(self, "auth_token")
+
+
+class RFarmStatus(PropertyGroup):
+    last_job_id: StringProperty(
+        name="Last Job ID",
+        description="Identifier of the last submitted remote job",
+        default="",
+    )
+    last_output_path: StringProperty(
+        name="Last Output Path",
+        description="Absolute path to the file produced by the remote render",
+        default="",
+        subtype="FILE_PATH",
+    )
+    is_rendering: BoolProperty(
+        name="Is Rendering",
+        description="True while Blender waits for a response from the remote worker",
+        default=False,
+    )
+    last_error: StringProperty(
+        name="Last Error",
+        description="Error message returned during the previous remote render",
+        default="",
+    )
+
+
+class RFarm_PT_panel(Panel):
+    bl_label = "R-Farm Remote Render"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "render"
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.render.engine == "CYCLES"
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        status = scene.rfarm_status
+
+        layout.label(text="Submit the active frame to the configured R-Farm backend.")
+        if status.is_rendering:
+            layout.label(text="Status: waiting for response", icon="TIME")
+        elif status.last_error:
+            layout.label(text=f"Error: {status.last_error}", icon="ERROR")
+        elif status.last_job_id:
+            layout.label(text=f"Last job: {status.last_job_id}", icon="INFO")
+            if status.last_output_path:
+                layout.label(text=f"Saved to: {status.last_output_path}", icon="FILE")
+
+        layout.separator()
+        layout.operator(RFarm_OT_render_frame.bl_idname, icon="RENDER_STILL")
+
+
+def _ensure_output_directory(path: Path) -> None:
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _collect_render_metadata(scene) -> dict:
+    render = scene.render
+    cycles = scene.cycles
+    metadata = {
+        "resolution_x": render.resolution_x,
+        "resolution_y": render.resolution_y,
+        "resolution_percentage": render.resolution_percentage,
+        "samples": getattr(cycles, "samples", None),
+        "preview_samples": getattr(cycles, "preview_samples", None),
+        "use_adaptive_sampling": getattr(cycles, "use_adaptive_sampling", None),
+        "file_format": render.image_settings.file_format,
+        "color_mode": render.image_settings.color_mode,
+        "color_depth": render.image_settings.color_depth,
+        "use_file_extension": render.use_file_extension,
+        "filepath": render.filepath,
+    }
+    return metadata
+
+
+def _build_payload(scene, blend_path: Path, preferences: RFarmAddonPreferences) -> dict:
+    with open(blend_path, "rb") as handle:
+        blend_encoded = base64.b64encode(handle.read()).decode("ascii")
+
+    payload = {
+        "frame": scene.frame_current,
+        "blend_file": blend_encoded,
+        "render_settings": _collect_render_metadata(scene),
+    }
+
+    compute_device = "CUDA"
+    cycles = scene.cycles
+    if getattr(cycles, "device", "CPU") == "GPU":
+        prefs = bpy.context.preferences.addons.get("cycles")
+        if prefs:
+            compute_device = prefs.preferences.compute_device_type
+        else:
+            compute_device = "CUDA"
+    payload["device"] = cycles.device
+    payload["compute_device_type"] = compute_device
+
+    return payload
+
+
+class RFarm_OT_render_frame(Operator):
+    bl_idname = "rfarm.render_frame"
+    bl_label = "Render Current Frame on R-Farm"
+    bl_description = "Upload the current .blend and render the active frame on Cloud Run"
+
+    def _resolve_output_path(self, scene) -> Optional[Path]:
+        render = scene.render
+        frame = scene.frame_current
+        filepath = bpy.path.abspath(render.frame_path(frame=frame))
+        if not filepath:
+            return None
+        return Path(filepath)
+
+    def execute(self, context):
+        scene = context.scene
+        status = scene.rfarm_status
+        prefs = context.preferences.addons[__name__].preferences
+
+        if requests is None:
+            message = "Python module 'requests' is required. Install it in Blender's Python environment."
+            status.last_error = message
+            self.report({"ERROR"}, message)
+            return {"CANCELLED"}
+
+        if not prefs.endpoint:
+            self.report({"ERROR"}, "Configure the Cloud Run endpoint in the add-on preferences.")
+            status.last_error = "Cloud Run endpoint not configured"
+            return {"CANCELLED"}
+
+        if scene.render.engine != "CYCLES":
+            self.report({"ERROR"}, "Switch the render engine to Cycles before submitting.")
+            status.last_error = "Render engine must be Cycles"
+            return {"CANCELLED"}
+
+        tmpdir = Path(tempfile.mkdtemp(prefix="rfarm_"))
+        blend_path = tmpdir / "scene.blend"
+        try:
+            bpy.ops.wm.save_as_mainfile(filepath=str(blend_path), copy=True)
+        except RuntimeError as ex:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            status.last_error = str(ex)
+            self.report({"ERROR"}, f"Unable to export .blend: {ex}")
+            return {"CANCELLED"}
+
+        payload = _build_payload(scene, blend_path, prefs)
+        url = prefs.endpoint.rstrip("/") + "/render"
+
+        headers = {"Content-Type": "application/json"}
+        if prefs.auth_token:
+            headers["Authorization"] = f"Bearer {prefs.auth_token}"
+
+        status.is_rendering = True
+        status.last_error = ""
+        status.last_output_path = ""
+        self.report({"INFO"}, "Submitting remote render job...")
+
+        try:
+            response = requests.post(url, headers=headers, data=json.dumps(payload), timeout=300)
+        except requests.RequestException as exc:
+            status.is_rendering = False
+            status.last_error = str(exc)
+            self.report({"ERROR"}, f"Request failed: {exc}")
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            return {"CANCELLED"}
+
+        if response.status_code >= 400:
+            status.is_rendering = False
+            status.last_error = f"HTTP {response.status_code}: {response.text}"
+            self.report({"ERROR"}, status.last_error)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            return {"CANCELLED"}
+
+        try:
+            payload_response = response.json()
+        except ValueError:
+            status.is_rendering = False
+            status.last_error = "Invalid JSON response"
+            self.report({"ERROR"}, status.last_error)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            return {"CANCELLED"}
+
+        status.last_job_id = payload_response.get("job_id", "")
+        image_base64 = payload_response.get("image_base64")
+        remote_format = payload_response.get("output_format", "PNG")
+        output_path = self._resolve_output_path(scene)
+
+        if image_base64 and output_path:
+            _ensure_output_directory(output_path)
+            try:
+                with open(output_path, "wb") as out_file:
+                    out_file.write(base64.b64decode(image_base64))
+                status.last_output_path = str(output_path)
+                self.report({"INFO"}, f"Remote render complete: {output_path}")
+            except OSError as exc:
+                status.last_error = str(exc)
+                self.report({"ERROR"}, f"Failed to write output: {exc}")
+        elif image_base64:
+            # Fall back to a temporary directory inside Blender's session.
+            temp_dir = Path(bpy.app.tempdir or tempfile.gettempdir())
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            fallback_name = f"rfarm_frame.{remote_format.lower()}"
+            temp_path = temp_dir / fallback_name
+            try:
+                with open(temp_path, "wb") as out_file:
+                    out_file.write(base64.b64decode(image_base64))
+                status.last_output_path = str(temp_path)
+                self.report({"INFO"}, f"Saved remote render to temporary path: {temp_path}")
+            except OSError as exc:
+                status.last_error = str(exc)
+                self.report({"ERROR"}, f"Failed to write temporary output: {exc}")
+        elif not image_base64:
+            status.last_error = "Response missing image data"
+            self.report({"WARNING"}, "Remote worker did not return image bytes.")
+
+        status.is_rendering = False
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        return {"FINISHED"}
+
+
+classes = (
+    RFarmAddonPreferences,
+    RFarmStatus,
+    RFarm_PT_panel,
+    RFarm_OT_render_frame,
+)
+
+
+def register():
+    for cls in classes:
+        register_class(cls)
+    bpy.types.Scene.rfarm_status = PointerProperty(type=RFarmStatus)
+
+
+def unregister():
+    for cls in reversed(classes):
+        unregister_class(cls)
+    if hasattr(bpy.types.Scene, "rfarm_status"):
+        del bpy.types.Scene.rfarm_status
+
+
+if __name__ == "__main__":
+    register()

--- a/cloud_run/Dockerfile
+++ b/cloud_run/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        wget \
+        ca-certificates \
+        libx11-6 \
+        libxi6 \
+        libxxf86vm1 \
+        libxfixes3 \
+        libxrender1 \
+        libgl1 \
+        libglu1 \
+        python3 \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG BLENDER_VERSION=3.6.5
+ARG BLENDER_DIST=blender-${BLENDER_VERSION}-linux-x64
+
+RUN wget -q https://download.blender.org/release/Blender${BLENDER_VERSION%.*}/${BLENDER_DIST}.tar.xz -O /tmp/blender.tar.xz \
+    && tar -xJf /tmp/blender.tar.xz -C /opt \
+    && ln -s /opt/${BLENDER_DIST}/blender /usr/local/bin/blender \
+    && rm /tmp/blender.tar.xz
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY app.py render_worker.py start.sh ./
+RUN chmod +x start.sh
+
+ENV BLENDER_USER_CONFIG=/tmp/blender
+ENV BLENDER_SYSTEM_SCRIPTS=/opt/${BLENDER_DIST}/${BLENDER_VERSION%.*}/scripts
+ENV BLENDER_SYSTEM_DATAFILES=/opt/${BLENDER_DIST}/${BLENDER_VERSION%.*}/datafiles
+
+CMD ["./start.sh"]

--- a/cloud_run/app.py
+++ b/cloud_run/app.py
@@ -1,0 +1,167 @@
+"""FastAPI application powering the R-Farm Cloud Run render worker."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+APP_ROOT = Path(__file__).resolve().parent
+BLENDER_EXECUTABLE = os.environ.get("BLENDER_EXECUTABLE", "blender")
+RENDER_SCRIPT = APP_ROOT / "render_worker.py"
+
+app = FastAPI(title="R-Farm Render Worker", version="0.1.0")
+
+
+class RenderSettings(BaseModel):
+    resolution_x: Optional[int] = None
+    resolution_y: Optional[int] = None
+    resolution_percentage: Optional[int] = Field(default=None, ge=1, le=100)
+    samples: Optional[int] = Field(default=None, ge=1)
+    preview_samples: Optional[int] = Field(default=None, ge=1)
+    use_adaptive_sampling: Optional[bool] = None
+    file_format: Optional[str] = None
+    color_mode: Optional[str] = None
+    color_depth: Optional[str] = None
+    use_file_extension: Optional[bool] = True
+    filepath: Optional[str] = None
+
+
+class RenderRequest(BaseModel):
+    frame: int = Field(description="Frame number to render")
+    blend_file: str = Field(description="Base64 encoded .blend content")
+    render_settings: RenderSettings = Field(default_factory=RenderSettings)
+    device: str = Field(default="GPU", description="Either GPU or CPU")
+    compute_device_type: str = Field(default="CUDA", description="Cycles compute device")
+
+
+class RenderResponse(BaseModel):
+    job_id: str
+    image_base64: str
+    output_format: str
+    output_path: str
+    logs: Optional[str] = None
+
+
+@app.get("/healthz")
+def healthcheck() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+def _write_blend_file(tmp_dir: Path, blend_data: str) -> Path:
+    blend_path = tmp_dir / "scene.blend"
+    with open(blend_path, "wb") as handle:
+        handle.write(base64.b64decode(blend_data))
+    return blend_path
+
+
+def _run_blender(blend_path: Path, request: RenderRequest) -> Dict[str, Any]:
+    output_dir = blend_path.parent / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_basename = "frame"
+    script_args = [
+        "--frame",
+        str(request.frame),
+        "--output-dir",
+        str(output_dir),
+        "--output-basename",
+        output_basename,
+        "--device",
+        request.device,
+        "--compute-device",
+        request.compute_device_type,
+    ]
+
+    settings = request.render_settings
+    if settings.samples is not None:
+        script_args.extend(["--samples", str(settings.samples)])
+    if settings.resolution_x is not None:
+        script_args.extend(["--resolution-x", str(settings.resolution_x)])
+    if settings.resolution_y is not None:
+        script_args.extend(["--resolution-y", str(settings.resolution_y)])
+    if settings.resolution_percentage is not None:
+        script_args.extend(["--resolution-percentage", str(settings.resolution_percentage)])
+    if settings.file_format is not None:
+        script_args.extend(["--file-format", settings.file_format])
+    if settings.color_mode is not None:
+        script_args.extend(["--color-mode", settings.color_mode])
+    if settings.color_depth is not None:
+        script_args.extend(["--color-depth", settings.color_depth])
+    if settings.use_adaptive_sampling is not None:
+        script_args.extend(["--use-adaptive-sampling", str(int(settings.use_adaptive_sampling))])
+
+    command = [
+        BLENDER_EXECUTABLE,
+        "--background",
+        str(blend_path),
+        "--python",
+        str(RENDER_SCRIPT),
+        "--",
+    ] + script_args
+
+    result = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+
+    logs = result.stdout
+    if result.returncode != 0:
+        raise HTTPException(status_code=500, detail=f"Blender failed: {logs[-2000:]}")
+
+    output_path = None
+    for line in logs.splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "output_path" in payload:
+            output_path = Path(payload["output_path"])
+            break
+
+    if not output_path or not output_path.exists():
+        raise HTTPException(status_code=500, detail="Render worker did not produce output")
+
+    encoded = base64.b64encode(output_path.read_bytes()).decode("ascii")
+    return {
+        "output_path": str(output_path),
+        "image_base64": encoded,
+        "logs": logs,
+    }
+
+
+@app.post("/render", response_model=RenderResponse)
+async def render_endpoint(request: RenderRequest) -> RenderResponse:
+    job_id = str(uuid.uuid4())
+    tmp_dir = Path(tempfile.mkdtemp(prefix="rfarm_"))
+    blend_path: Optional[Path] = None
+    try:
+        blend_path = _write_blend_file(tmp_dir, request.blend_file)
+        result = _run_blender(blend_path, request)
+        output_path = Path(result["output_path"])
+        output_format = output_path.suffix.lstrip(".").upper() or request.render_settings.file_format or "PNG"
+        return RenderResponse(
+            job_id=job_id,
+            image_base64=result["image_base64"],
+            output_format=output_format,
+            output_path=str(output_path),
+            logs=result["logs"],
+        )
+    finally:
+        if blend_path and blend_path.exists():
+            try:
+                blend_path.unlink()
+            except OSError:
+                pass
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/cloud_run/render_worker.py
+++ b/cloud_run/render_worker.py
@@ -1,0 +1,89 @@
+"""Helper script executed within Blender to render a single frame with GPU."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import bpy
+
+
+def _configure_cycles(device: str, compute_device: str) -> None:
+    cycles_addon = bpy.context.preferences.addons.get("cycles")
+    if not cycles_addon:
+        raise RuntimeError("Cycles add-on not available in this Blender build")
+
+    prefs = cycles_addon.preferences
+    prefs.get_devices()
+    compute_device = compute_device.upper()
+    prefs.compute_device_type = compute_device
+    for device_item in prefs.devices:
+        if device_item.type == compute_device:
+            device_item.use = True
+        elif device_item.type == "CPU":
+            device_item.use = device.upper() != "GPU"
+        else:
+            device_item.use = False
+
+    scene = bpy.context.scene
+    scene.cycles.device = "GPU" if device.upper() == "GPU" else "CPU"
+
+
+def _apply_render_settings(args: argparse.Namespace) -> None:
+    scene = bpy.context.scene
+    if args.samples is not None:
+        scene.cycles.samples = args.samples
+    if args.resolution_x is not None:
+        scene.render.resolution_x = args.resolution_x
+    if args.resolution_y is not None:
+        scene.render.resolution_y = args.resolution_y
+    if args.resolution_percentage is not None:
+        scene.render.resolution_percentage = args.resolution_percentage
+    if args.file_format is not None:
+        scene.render.image_settings.file_format = args.file_format
+    if args.color_mode is not None:
+        scene.render.image_settings.color_mode = args.color_mode
+    if args.color_depth is not None:
+        scene.render.image_settings.color_depth = args.color_depth
+    if args.use_adaptive_sampling is not None:
+        scene.cycles.use_adaptive_sampling = bool(int(args.use_adaptive_sampling))
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    scene.render.filepath = str(output_dir / args.output_basename)
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(description="Execute a single Cycles render")
+    parser.add_argument("--frame", type=int, required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--output-basename", required=True)
+    parser.add_argument("--device", default="GPU")
+    parser.add_argument("--compute-device", default="CUDA")
+    parser.add_argument("--samples", type=int, default=None)
+    parser.add_argument("--resolution-x", type=int, default=None)
+    parser.add_argument("--resolution-y", type=int, default=None)
+    parser.add_argument("--resolution-percentage", type=int, default=None)
+    parser.add_argument("--file-format", default=None)
+    parser.add_argument("--color-mode", default=None)
+    parser.add_argument("--color-depth", default=None)
+    parser.add_argument("--use-adaptive-sampling", default=None)
+
+    args = parser.parse_args(argv)
+
+    bpy.context.scene.frame_set(args.frame)
+    _configure_cycles(args.device, args.compute_device)
+    _apply_render_settings(args)
+
+    bpy.ops.render.render(write_still=True)
+
+    output_path = bpy.path.abspath(bpy.context.scene.render.frame_path(frame=args.frame))
+    print(json.dumps({"output_path": output_path}))
+
+
+if __name__ == "__main__":
+    if "--" in sys.argv:
+        arg_list = sys.argv[sys.argv.index("--") + 1 :]
+    else:
+        arg_list = sys.argv[1:]
+    main(arg_list)

--- a/cloud_run/requirements.txt
+++ b/cloud_run/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+pydantic==2.7.1

--- a/cloud_run/start.sh
+++ b/cloud_run/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-8080}"
+exec uvicorn app:app --host 0.0.0.0 --port "${PORT}"


### PR DESCRIPTION
## Summary
- create a Blender add-on that submits the active Cycles frame to a remote render worker
- add a FastAPI-based GPU Cloud Run service and container image to execute Blender renders
- document installation, deployment, and usage instructions for the prototype render farm

## Testing
- python3 -m py_compile cloud_run/app.py cloud_run/render_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68e1176680288326b930e101b0a027fa