### PR TITLE
Normalize start script line endings in Docker build

### DIFF
--- a/cloud_run/Dockerfile
+++ b/cloud_run/Dockerfile
@@ -38,6 +38,7 @@ COPY requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY app.py render_worker.py start.sh ./
+RUN sed -i 's/\r$//' start.sh
 RUN chmod +x start.sh
 
 ENV BLENDER_USER_CONFIG=/tmp/blender


### PR DESCRIPTION
## Summary
- normalize start.sh line endings in the Cloud Run Dockerfile to avoid Windows carriage returns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b4a54af08326acde9e4ed219c114