### PR TITLE
Add Cloud Storage upload workflow for Blender jobs

### DIFF
--- a/cloud_run/app.py
+++ b/cloud_run/app.py
@@ -9,15 +9,22 @@ import shutil
 import subprocess
 import tempfile
 import uuid
+from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from fastapi import FastAPI, HTTPException
+from google.api_core import exceptions as gcs_exceptions
+from google.cloud import storage
 from pydantic import BaseModel, Field
 
 APP_ROOT = Path(__file__).resolve().parent
 BLENDER_EXECUTABLE = os.environ.get("BLENDER_EXECUTABLE", "blender")
 RENDER_SCRIPT = APP_ROOT / "render_worker.py"
+GCS_BUCKET = os.environ.get("RFARM_GCS_BUCKET")
+SIGNED_URL_TTL_MINUTES = int(os.environ.get("RFARM_SIGNED_URL_TTL_MINUTES", "15"))
+
+_storage_client: Optional[storage.Client] = None
 
 app = FastAPI(title="R-Farm Render Worker", version="0.1.0")
 
@@ -38,7 +45,13 @@ class RenderSettings(BaseModel):
 
 class RenderRequest(BaseModel):
     frame: int = Field(description="Frame number to render")
-    blend_file: str = Field(description="Base64 encoded .blend content")
+    blend_file: Optional[str] = Field(
+        default=None, description="Base64 encoded .blend content (legacy mode)",
+    )
+    blend_gcs_uri: Optional[str] = Field(
+        default=None,
+        description="gs:// URI pointing at the .blend file uploaded to Cloud Storage",
+    )
     render_settings: RenderSettings = Field(default_factory=RenderSettings)
     device: str = Field(default="GPU", description="Either GPU or CPU")
     compute_device_type: str = Field(default="OPTIX", description="Cycles compute device")
@@ -53,8 +66,29 @@ class RenderResponse(BaseModel):
 
 
 @app.get("/healthz")
+class BlendUploadRequest(BaseModel):
+    filename: str = Field(
+        default="scene.blend",
+        description="Name of the .blend file used to compose the Cloud Storage object",
+    )
+
+
+class BlendUploadResponse(BaseModel):
+    upload_url: str
+    blob_name: str
+    gcs_uri: str
+    expires_in: int = Field(description="Validity of the signed URL in seconds")
+
+
 def healthcheck() -> Dict[str, str]:
     return {"status": "ok"}
+
+
+def _get_storage_client() -> storage.Client:
+    global _storage_client
+    if _storage_client is None:
+        _storage_client = storage.Client()
+    return _storage_client
 
 
 def _write_blend_file(tmp_dir: Path, blend_data: str) -> Path:
@@ -62,6 +96,34 @@ def _write_blend_file(tmp_dir: Path, blend_data: str) -> Path:
     with open(blend_path, "wb") as handle:
         handle.write(base64.b64decode(blend_data))
     return blend_path
+
+
+def _parse_gcs_uri(gcs_uri: str) -> Tuple[str, str]:
+    if not gcs_uri.startswith("gs://"):
+        raise HTTPException(status_code=400, detail="Invalid GCS URI")
+    path = gcs_uri[5:]
+    try:
+        bucket_name, blob_name = path.split("/", 1)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid GCS URI") from exc
+    if not bucket_name or not blob_name:
+        raise HTTPException(status_code=400, detail="Invalid GCS URI")
+    return bucket_name, blob_name
+
+
+def _download_blend_from_gcs(tmp_dir: Path, gcs_uri: str) -> Path:
+    bucket_name, blob_name = _parse_gcs_uri(gcs_uri)
+    try:
+        client = _get_storage_client()
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        destination = tmp_dir / "scene.blend"
+        blob.download_to_filename(destination)
+    except gcs_exceptions.GoogleAPIError as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to download blend file: {exc}") from exc
+    if not destination.exists():
+        raise HTTPException(status_code=500, detail="Blend download failed")
+    return destination
 
 
 def _run_blender(blend_path: Path, request: RenderRequest) -> Dict[str, Any]:
@@ -147,7 +209,12 @@ async def render_endpoint(request: RenderRequest) -> RenderResponse:
     tmp_dir = Path(tempfile.mkdtemp(prefix="rfarm_"))
     blend_path: Optional[Path] = None
     try:
-        blend_path = _write_blend_file(tmp_dir, request.blend_file)
+        if request.blend_gcs_uri:
+            blend_path = _download_blend_from_gcs(tmp_dir, request.blend_gcs_uri)
+        elif request.blend_file:
+            blend_path = _write_blend_file(tmp_dir, request.blend_file)
+        else:
+            raise HTTPException(status_code=400, detail="Missing blend file reference")
         result = _run_blender(blend_path, request)
         output_path = Path(result["output_path"])
         output_format = output_path.suffix.lstrip(".").upper() or request.render_settings.file_format or "PNG"
@@ -165,3 +232,33 @@ async def render_endpoint(request: RenderRequest) -> RenderResponse:
             except OSError:
                 pass
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+@app.post("/upload-url", response_model=BlendUploadResponse)
+async def create_upload_url(request: BlendUploadRequest) -> BlendUploadResponse:
+    if not GCS_BUCKET:
+        raise HTTPException(status_code=500, detail="RFARM_GCS_BUCKET is not configured")
+
+    object_name = f"uploads/{uuid.uuid4()}/{request.filename}"
+    expiration = timedelta(minutes=SIGNED_URL_TTL_MINUTES)
+
+    try:
+        client = _get_storage_client()
+        bucket = client.bucket(GCS_BUCKET)
+        blob = bucket.blob(object_name)
+        upload_url = blob.generate_signed_url(
+            version="v4",
+            expiration=expiration,
+            method="PUT",
+            content_type="application/octet-stream",
+        )
+    except gcs_exceptions.GoogleAPIError as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to generate upload URL: {exc}") from exc
+
+    gcs_uri = f"gs://{GCS_BUCKET}/{object_name}"
+    return BlendUploadResponse(
+        upload_url=upload_url,
+        blob_name=object_name,
+        gcs_uri=gcs_uri,
+        expires_in=int(expiration.total_seconds()),
+    )

--- a/cloud_run/requirements.txt
+++ b/cloud_run/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
 pydantic==2.7.1
+google-cloud-storage==2.16.0


### PR DESCRIPTION
## Summary
- add a signed URL endpoint in the render worker and download support for Cloud Storage hosted .blend files
- update the Blender add-on to upload serialized scenes to Cloud Storage before triggering renders
- document the new workflow and include the Cloud Storage client dependency

## Testing
- python -m compileall blender_addon cloud_run

------
https://chatgpt.com/codex/tasks/task_e_68e3806523988326bcda03b6cbe01a52