### PR TITLE
Fix health check route registration

### DIFF
--- a/cloud_run/app.py
+++ b/cloud_run/app.py
@@ -65,7 +65,6 @@ class RenderResponse(BaseModel):
     logs: Optional[str] = None
 
 
-@app.get("/healthz")
 class BlendUploadRequest(BaseModel):
     filename: str = Field(
         default="scene.blend",
@@ -80,6 +79,7 @@ class BlendUploadResponse(BaseModel):
     expires_in: int = Field(description="Validity of the signed URL in seconds")
 
 
+@app.get("/healthz")
 def healthcheck() -> Dict[str, str]:
     return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- move the `/healthz` decorator back onto the `healthcheck` handler so FastAPI registers the route correctly

## Testing
- python -m compileall blender_addon cloud_run

------
https://chatgpt.com/codex/tasks/task_e_68ed49a6c1b48326a530d5ced6c36d36