### PR TITLE
Add legacy upload fallback in add-on and align worker routes

### DIFF
--- a/cloud_run/app.py
+++ b/cloud_run/app.py
@@ -65,7 +65,6 @@ class RenderResponse(BaseModel):
     logs: Optional[str] = None
 
 
-@app.get("/healthz")
 class BlendUploadRequest(BaseModel):
     filename: str = Field(
         default="scene.blend",
@@ -80,6 +79,7 @@ class BlendUploadResponse(BaseModel):
     expires_in: int = Field(description="Validity of the signed URL in seconds")
 
 
+@app.get("/healthz")
 def healthcheck() -> Dict[str, str]:
     return {"status": "ok"}
 
@@ -262,3 +262,10 @@ async def create_upload_url(request: BlendUploadRequest) -> BlendUploadResponse:
         gcs_uri=gcs_uri,
         expires_in=int(expiration.total_seconds()),
     )
+
+
+@app.post("/upload", response_model=BlendUploadResponse, include_in_schema=False)
+async def create_upload_url_legacy(request: BlendUploadRequest) -> BlendUploadResponse:
+    """Compatibility shim for older Blender add-on versions."""
+
+    return await create_upload_url(request)


### PR DESCRIPTION
## Summary
- add a graceful fallback in the Blender add-on when /upload-url is unavailable
- fix the worker health check decorator and expose a legacy /upload endpoint for older clients

## Testing
- python -m compileall blender_addon cloud_run

------
https://chatgpt.com/codex/tasks/task_e_68ed59abbe0c8326a1b2ba89fc92191b