### PR TITLE
Fix missing libxkbcommon dependency in render image

### DIFF
--- a/cloud_run/Dockerfile
+++ b/cloud_run/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
         libxrender1 \
         libgl1 \
         libglu1 \
+        libxkbcommon0 \
         python3 \
         python3-pip \
         python3-venv \


### PR DESCRIPTION
## Summary
- include libxkbcommon0 in the base image packages so Blender can load its shared libraries at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed762852388326b031c2179eb90260