### PR TITLE
Install libssl runtime dependency

### DIFF
--- a/cloud_run/Dockerfile
+++ b/cloud_run/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
         libgl1 \
         libglu1 \
         libxkbcommon0 \
+        libssl3 \
         python3 \
         python3-pip \
         python3-venv \


### PR DESCRIPTION
## Summary
- install the libssl3 package in the render worker Docker image so Blender can start

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed7942a6d08326b28c8c987f1304f1